### PR TITLE
Bootstrap tooling and scaffold packages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+CLAUDE_API_KEY=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["next", "prettier"],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -f ~/.huskyrc ]; then
+  . ~/.huskyrc
+fi
+
+hookname=$(basename "$0")
+
+a="husky-run"; b="$HUSKY_GIT_PARAMS"; [ "$b" = "" ] && b="$*"; npx --no -- "$a" "$hookname" "$b"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@
 
 ## 🌟 Vision
 
-Arcanea is a myth-tech ecosystem that combines AI, storytelling, and personal development. It consists of:
+Arcanea is a myth-tech ecosystem that combines AI, storytelling, and personal development.
+It currently provides a minimal web portal and a small OpenRouter wrapper package.
+Many features referenced in early plans are still under development.
 
-- **Web Portal**: Interactive platform to explore the Arcanean Thread Matrix
-- **Mobile App (planned)**: Native experience for engaging with Thread Guardians
+**Components**
+- **Web Portal**: Next.js application for exploring basic concepts
 - **API Layer**: Powered by Claude AI through OpenRouter
-- **Core Library**: Shared TypeScript/JavaScript modules
+- **Mobile App**: _planned_
+- **Shared UI/Types packages**: _planned_
 
 ## 🚀 Quick Start
 
@@ -66,14 +69,12 @@ arcanea/
 │   └── openrouter-wrapper/  # TypeScript client for OpenRouter API
 ```
 
-## 🧩 Key Features
+## 🧩 Planned Features
 ### Web Portal
 - Interactive Thread Matrix visualization
-- Responsive design with dark/light mode
 - Real-time chat with AI Thread Guardians
 - User authentication and profiles
-### Core Features
-- Type-safe API client
+### Core
 - Shared UI component library
 - Theming system
 - Internationalization (i18n) support
@@ -111,6 +112,12 @@ This project uses:
 - [Prettier](https://prettier.io/) for code formatting
 - [ESLint](https://eslint.org/) for code quality
 - [TypeScript](https://www.typescriptlang.org/) for type safety
+
+## 📂 Arcanea Context
+
+The repository includes an `arcanea-context` file containing lore and design
+principles for the project. Contributors should review it to understand the
+mythology and terminology used across Arcanea.
 
 ## 🤝 Contributing
 

--- a/apps/web-portal/next.config.js
+++ b/apps/web-portal/next.config.js
@@ -1,4 +1,5 @@
 /** @type {import('next').NextConfig} */
+const path = require('path');
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,

--- a/apps/web-portal/src/app/globals.css
+++ b/apps/web-portal/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web-portal/src/app/layout.tsx
+++ b/apps/web-portal/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/web-portal/src/app/page.tsx
+++ b/apps/web-portal/src/app/page.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+export default function Home() {
+  return (
+    <main className="p-8 flex justify-center">
+      <Card>
+        <CardHeader>
+          <CardTitle>Welcome to Arcanea</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button variant="obsidian">Get Started</Button>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "test": "turbo run test",
+    "test": "vitest",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "type-check": "turbo run type-check",
     "prepare": "husky install"
@@ -23,7 +23,8 @@
     "prettier": "^3.0.2",
     "prettier-plugin-tailwindcss": "^0.5.1",
     "turbo": "^1.10.12",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vitest": "^0.34.5"
   },
   "packageManager": "pnpm@8.6.12",
   "engines": {

--- a/packages/openrouter-wrapper/README.md
+++ b/packages/openrouter-wrapper/README.md
@@ -1,0 +1,13 @@
+# OpenRouter Wrapper
+
+A tiny client for interacting with the OpenRouter API used by Arcanea. It reads
+configuration from environment variables.
+
+## Usage
+
+```
+import { createClient } from '@arcanea/openrouter-wrapper'
+const client = createClient()
+```
+
+Set `CLAUDE_API_KEY` in your `.env` file.

--- a/packages/openrouter-wrapper/__tests__/config.test.ts
+++ b/packages/openrouter-wrapper/__tests__/config.test.ts
@@ -1,0 +1,8 @@
+import { config } from '../src/config'
+import { describe, it, expect } from 'vitest'
+
+describe('config', () => {
+  it('loads API key from env', () => {
+    expect(typeof config.claudeApiKey).toBe('string')
+  })
+})

--- a/packages/openrouter-wrapper/package.json
+++ b/packages/openrouter-wrapper/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@arcanea/openrouter-wrapper",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^0.34.5",
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/openrouter-wrapper/src/index.ts
+++ b/packages/openrouter-wrapper/src/index.ts
@@ -1,0 +1,26 @@
+import { config } from './config'
+import fetch from 'node-fetch'
+
+export interface MessageRequest {
+  prompt: string
+}
+
+export async function sendMessage(req: MessageRequest): Promise<string> {
+  const res = await fetch(config.claudeApiEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${config.claudeApiKey}`
+    },
+    body: JSON.stringify({ prompt: req.prompt, model: config.defaultModel })
+  })
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`)
+  }
+  const data = await res.json() as { completion: string }
+  return data.completion
+}
+
+export function createClient() {
+  return { sendMessage }
+}

--- a/packages/openrouter-wrapper/tsconfig.json
+++ b/packages/openrouter-wrapper/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2 @@
+lockfileVersion: 5.4
+importers: {}

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('smoke', () => {
+  it('runs', () => {
+    expect(1).toBe(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- fix missing path import in Next.js config
- add .env example
- document current repo setup in README and explain arcanea context
- scaffold `openrouter-wrapper` package
- set up ESLint, Prettier, CI workflow and Husky
- add minimal landing page for web portal
- add vitest test infrastructure
- commit placeholder pnpm lockfile

## Testing
- `pnpm lint` *(fails: unable to download pnpm packages)*
- `pnpm test` *(fails: unable to download pnpm packages)*
